### PR TITLE
feat: Add htmltest to the documenation build

### DIFF
--- a/.github/workflows/pr-checks.yaml
+++ b/.github/workflows/pr-checks.yaml
@@ -17,11 +17,11 @@ jobs:
 
       - uses: actions/setup-node@v3
 
-      - name: Install
-        run: yarn install --immutable
-
       - name: Lint
-        run: yarn lint
+        run: make lint
 
       - name: Build
-        run: yarn build
+        run: make build
+      
+      - name: Test
+        run: make test

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 # Generated files
 .docusaurus
 .cache-loader
+tmp/
 
 # Misc
 .DS_Store

--- a/.htmltest.yml
+++ b/.htmltest.yml
@@ -1,0 +1,4 @@
+
+IgnoreURLs: []
+IgnoreDirectoryMissingTrailingSlash: true
+IgnoreAltMissing: true

--- a/docs/reference/concepts/02-provider.mdx
+++ b/docs/reference/concepts/02-provider.mdx
@@ -346,7 +346,7 @@ Be sure to document this behavior.
 
 #### How should I handle error conditions?
 
-If an error condition is encountered in your provider, an error should be [indicated](/docs/specification/sections/providers#flag-value-resolution) by throwing or returning an error, as language idioms dictate. The SDK will ensure the default value is returned and expose the relevant error data.
+If an error condition is encountered in your provider, an error should be [indicated](/docs/specification/types#error-code) by throwing or returning an error, as language idioms dictate. The SDK will ensure the default value is returned and expose the relevant error data.
 
 #### My flag system doesn't support flags of a particular type. What should I do?
 

--- a/docs/reference/concepts/03-evaluation-context.mdx
+++ b/docs/reference/concepts/03-evaluation-context.mdx
@@ -125,7 +125,7 @@ $boolValue = $client->getBooleanValue("boolFlag", false, $context);
 
 ### Context merging
 
-At the point of flag evaluation, the evaluation context is merged, and duplicate values are overwritten as defined in the [specification](/docs/specification/sections/evaluation-context#merging-context).
+At the point of flag evaluation, the evaluation context is merged, and duplicate values are overwritten as defined in the [specification](/docs/specification/sections/evaluation-context#32-merging-context).
 
 ### Circular structures in Evaluation Context
 

--- a/makefile
+++ b/makefile
@@ -1,0 +1,36 @@
+
+VOLUMES := -v $(CURDIR):/docusaurus -w /docusaurus
+IMAGE := node:19-bullseye
+DOCKER := docker run --rm $(VOLUMES) -p 3000:3000 $(IMAGE)
+
+.PHONY: all build serve clean test lint
+
+all: yarn.lock
+
+yarn.lock: package.json node_modules
+	$(MAKE clean)
+	$(DOCKER) yarn install --immutable
+
+node_modules:
+	mkdir -p $@
+
+build: yarn.lock
+	$(DOCKER) yarn build
+
+version: yarn.lock
+	$(DOCKER) npx docusaurus --version
+
+serve: yarn.lock
+	$(DOCKER) yarn run serve
+
+start: yarn.lock
+	$(DOCKER) yarn run start -- --poll --host 0.0.0.0
+
+lint: yarn.lock
+	$(DOCKER) yarn run lint
+
+clean:
+	rm -rf ./node_modules
+
+test: build
+	docker run -v $(CURDIR):/test --rm wjdp/htmltest -s -c .htmltest.yml build

--- a/yarn.lock
+++ b/yarn.lock
@@ -1453,7 +1453,7 @@
     react-helmet-async "*"
     react-loadable "npm:@docusaurus/react-loadable@5.5.2"
 
-"@docusaurus/module-type-aliases@2.2.0", "@docusaurus/module-type-aliases@^2.2.0":
+"@docusaurus/module-type-aliases@2.2.0":
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/@docusaurus/module-type-aliases/-/module-type-aliases-2.2.0.tgz#1e23e54a1bbb6fde1961e4fa395b1b69f4803ba5"
   integrity sha512-wDGW4IHKoOr9YuJgy7uYuKWrDrSpsUSDHLZnWQYM9fN7D5EpSmYHjFruUpKWVyxLpD/Wh0rW8hYZwdjJIQUQCQ==


### PR DESCRIPTION
Keeping links in documentation up to date is hard, sometimes links are breaking, sometimes things will get moved around and the links are not up-to-date anymore. HTMLTests checks for certain things, and helps to keep the documentation up-to-date.

Additionally i added a makefile using docker to reduce the need of local dependencies and create a unified build experience for CI and local systems.

Signed-off-by: Simon Schrottner <simon.schrottner@dynatrace.com>